### PR TITLE
支持使用 Buffer 直接初始化

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,11 @@ console.log(city.findSync("123.121.17.72"));
 var district = new datx.District("/path/to/quxian.datx");
 // findSync 此方法只接受IPv4类型的IP地址，请自行检查参数是否符合规定；
 console.log(district.findSync("123.121.17.72")); 
+
+// 从非文件数据源加载最新的 datx 二进制内容
+var buffer = getFromSomewhere();
+var district = new datx.District(buffer);
+// findSync 此方法只接受IPv4类型的IP地址，请自行检查参数是否符合规定；
+console.log(district.findSync("123.121.17.72")); 
 </code>
 </pre>

--- a/lib/city.js
+++ b/lib/city.js
@@ -3,7 +3,13 @@ const net = require('net');
 
 module.exports = class City {
     constructor(name){
-        this.data = fs.readFileSync(name)
+        if (typeof name === 'string') {
+            this.data = fs.readFileSync(name)
+        } else if (name instanceof Buffer) {
+            this.data = name;
+        } else {
+            throw new TypeError('invalid name argument');
+        }
         this.indexSize = this.bytes2Uint32(
             this.data[0],
             this.data[1],

--- a/lib/district.js
+++ b/lib/district.js
@@ -3,7 +3,13 @@ var net = require("net");
 
 module.exports = class District {
     constructor(name){
-        this.data = fs.readFileSync(name);
+        if (typeof name === 'string') {
+            this.data = fs.readFileSync(name)
+        } else if (name instanceof Buffer) {
+            this.data = name;
+        } else {
+            throw new TypeError('invalid name argument');
+        }
         this.indexSize = this.bytes2Uint32(
             this.data[0],
             this.data[1],


### PR DESCRIPTION
工程中可能需要在内网通过类似 DB 的方式向不同业务分发 IP 库, 避免多次下载操作.
因此希望能直接用 Buffer 初始化 datx 解析实例.